### PR TITLE
ReadConsoleInput does not return

### DIFF
--- a/Nyancat/Drivers/WindowsConsoleDriver.cs
+++ b/Nyancat/Drivers/WindowsConsoleDriver.cs
@@ -171,16 +171,19 @@ namespace Nyancat.Drivers
                 if (err != 0)
                     throw new System.ComponentModel.Win32Exception(err);
             }
-
-            var records = new InputRecord[eventCount];
-
-            ReadConsoleInput(StdInputHandle, records, eventCount, out eventsRead);
-
-            if (eventsRead != 0)
+            
+            if(eventCount > 0)
             {
-                foreach (var record in records)
+                var records = new InputRecord[eventCount];
+
+                ReadConsoleInput(StdInputHandle, records, eventCount, out eventsRead);
+
+                if (eventsRead != 0)
                 {
-                    ProcessEventRecord(record);
+                    foreach (var record in records)
+                    {
+                        ProcessEventRecord(record);
+                    }
                 }
             }
         }


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/windows/console/readconsoleinput:
"The function does not return until at least one input record has been read"

Because of this, on Windows, the game loop freezes in one frame and is waiting for some event (window resize, mouse, keyboard..).. 
The workaround is to check for eventCount before the read..